### PR TITLE
Fixed ES5 class issue with latest NativeScript v7.0.11 and Angular v11.0.2

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "commonjs",
         "declaration": true,
         "removeComments": true,


### PR DESCRIPTION
Updated tsconfig.json -> compilerOptions -> target from es5 to es6 to fix **"TypeError: Class constructor View cannot be invoked without 'new'"** error with latest NativeScript v7.0.11 and Angular v11.0.2
## What is the current behavior?
working fine
[
![Screenshot_20201206_032824](https://user-images.githubusercontent.com/57581122/101266272-3c750200-3773-11eb-90ca-0192208d4520.jpg)
](url)
## What is the new behavior?
<!-- Describe the changes. -->

Fixes #14.

